### PR TITLE
Activate models auto drop down

### DIFF
--- a/CalibrationShapes.py
+++ b/CalibrationShapes.py
@@ -99,6 +99,7 @@ from UM.Settings.SettingInstance import SettingInstance
 from cura.Scene.CuraSceneNode import CuraSceneNode
 from UM.Scene.SceneNode import SceneNode
 from UM.Scene.Selection import Selection
+from UM.Scene.SceneNodeSettings import SceneNodeSettings
 from cura.Scene.SliceableObjectDecorator import SliceableObjectDecorator
 from cura.Scene.BuildPlateDecorator import BuildPlateDecorator
 from UM.Operations.AddSceneNodeOperation import AddSceneNodeOperation
@@ -864,7 +865,8 @@ class CalibrationShapes(QObject, Extension):
             new_instance.setProperty("value", mode)
             new_instance.resetState()  # Ensure that the state is not seen as a user state.
             settings.addInstance(new_instance)
-            
+
+        node.setSetting(SceneNodeSettings.AutoDropDown, True)
             
         active_build_plate = application.getMultiBuildPlateModel().activeBuildPlate
         node.addDecorator(BuildPlateDecorator(active_build_plate))
@@ -930,7 +932,9 @@ class CalibrationShapes(QObject, Extension):
         new_instance.setProperty("value", flow)
         new_instance.resetState()  # Ensure that the state is not seen as a user state.
         settings.addInstance(new_instance)
-        
+
+        node.setSetting(SceneNodeSettings.AutoDropDown, True)
+
         active_build_plate = application.getMultiBuildPlateModel().activeBuildPlate
         node.addDecorator(BuildPlateDecorator(active_build_plate))
 


### PR DESCRIPTION
Hi,

This is an easy workaround to fix the floating objects issue https://github.com/5axes/SpoonAntiWarping/issues/8. It activates the per-model "Drop Down Model" option on the generated calibration shapes, so that they will always be lying on the build plate.

While working on the topic, I actually found the root cause of the issue, which is that Cura assumes the 3D meshes to be centered on their bounding box when writing and reading 3MF files. This is the case when loading STL meshes because we do re-center them at load time. But for generated meshes like for this plugin, it doesn't work.
I have then opened a ticket for solving the root cause. However, this requires some time that we can't afford yet. So in the meantime, I suggest that we apply this change on the plugin, which at least avoids having floating objects.

Tell me what you think about it.

Partially fixes https://github.com/5axes/SpoonAntiWarping/issues/8